### PR TITLE
Fix searching on mobile

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -35,8 +35,9 @@ export default function HomePage() {
           value={search}
           onChange={(e) => setSearch(e.target.value)}
           onKeyDown={(e) => {
-            if (e.code == "Enter")
+            if (e.key === "Enter") {
               navigate(`/search?query=${encodeURIComponent(search.trim())}`);
+            }
           }}
         />
       </div>


### PR DESCRIPTION
# Description

Previously we were testing if the `code` enter is hit. This does produce anything on mobile. Now instead we check if the `key` enter is hit. This will work on mobile and browser.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I went to [keyjs.dev](https://keyjs.dev/) and tried to see what `e.key` and `e.code` would produce and both mobile and desktop views. On mobile view `e.code` does not produce anything for an enter while it does for desktop. `e.key` produces enter for both views.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
