### PR TITLE
Add searchparams for display settings

### DIFF
--- a/cypress/e2e/searchPage.cy.js
+++ b/cypress/e2e/searchPage.cy.js
@@ -43,7 +43,7 @@ describe("template spec", () => {
     cy.getTestId("card-text").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
 
-    cy.location("search").should("eq", "?query=draven&mode=text");
+    cy.location("search").should("eq", "?mode=text&query=draven");
 
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
@@ -57,7 +57,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
 
-    cy.location("search").should("eq", "?query=draven&mode=list");
+    cy.location("search").should("eq", "?mode=list&query=draven");
 
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
@@ -71,7 +71,7 @@ describe("template spec", () => {
     cy.getTestId("card-full").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
 
-    cy.location("search").should("eq", "?query=draven&mode=full");
+    cy.location("search").should("eq", "?mode=full&query=draven");
 
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
@@ -92,7 +92,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=descending",
+      "?direction=descending&mode=list&query=draven",
     );
 
     // rest back to default
@@ -100,7 +100,7 @@ describe("template spec", () => {
     cy.getTestId("select-direction-auto").click();
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto",
+      "?direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -109,7 +109,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX035");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=card_code",
+      "?attribute=card_code&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -118,7 +118,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T2");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=name",
+      "?attribute=name&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -127,7 +127,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T2");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=cost",
+      "?attribute=cost&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -136,7 +136,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T3");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=health",
+      "?attribute=health&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -145,7 +145,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T3");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=attack",
+      "?attribute=attack&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -154,7 +154,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX035");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=card_type",
+      "?attribute=card_type&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -163,7 +163,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=rarity",
+      "?attribute=rarity&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -172,7 +172,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T2");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=region_refs",
+      "?attribute=region_refs&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -181,7 +181,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX035");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=artist_name",
+      "?attribute=artist_name&direction=auto&mode=list&query=draven",
     );
 
     cy.getTestId("select-attribute").click();
@@ -190,7 +190,7 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").last().contains("01NX020T2");
     cy.location("search").should(
       "eq",
-      "?query=draven&mode=list&direction=auto&attribute=set",
+      "?attribute=set&direction=auto&mode=list&query=draven",
     );
   });
 
@@ -227,5 +227,29 @@ describe("template spec", () => {
         "include",
         "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T2.png",
       );
+  });
+
+  it("should use the same parameters when searching within search", () => {
+    cy.visit(
+      "/search?query=asd&mode=list&attribute=attack&direction=descending",
+    );
+    cy.getTestId("no-cards").should("exist");
+    cy.getTestId("card-list-item").should("not.exist");
+
+    cy.getTestId("nav-search-bar-input").clear().type("draven").type("{enter}");
+    cy.location("search").should(
+      "eq",
+      "?attribute=attack&direction=descending&mode=list&query=draven",
+    );
+    cy.getTestId("card-list-item").should("have.length", 4);
+    cy.getTestId("card-list-item").first().contains("01NX020T3");
+    cy.getTestId("card-list-item").last().contains("01NX020T2");
+    cy.getTestId("no-cards").should("not.exist");
+  });
+
+  it("should reset to default when searching from different page", () => {
+    cy.visit("/about");
+    cy.getTestId("nav-search-bar-input").type("draven").type("{enter}");
+    cy.url().should("eq", `${baseUrl}/search?query=draven`);
   });
 });

--- a/cypress/e2e/searchPage.cy.js
+++ b/cypress/e2e/searchPage.cy.js
@@ -43,6 +43,8 @@ describe("template spec", () => {
     cy.getTestId("card-text").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
 
+    cy.location("search").should("eq", "?query=draven&mode=text");
+
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
     cy.getTestId("card-text").should("not.exist");
@@ -55,6 +57,8 @@ describe("template spec", () => {
     cy.getTestId("card-list-item").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
 
+    cy.location("search").should("eq", "?query=draven&mode=list");
+
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
     cy.getTestId("card-list-item").should("not.exist");
@@ -66,6 +70,8 @@ describe("template spec", () => {
     cy.getTestId("select-mode-full").click();
     cy.getTestId("card-full").should("have.length", 4);
     cy.getTestId("no-cards").should("not.exist");
+
+    cy.location("search").should("eq", "?query=draven&mode=full");
 
     cy.visit("/search?query=asd");
     cy.getTestId("no-cards").should("exist");
@@ -84,59 +90,142 @@ describe("template spec", () => {
     cy.getTestId("select-direction-descending").click();
     cy.getTestId("card-list-item").first().contains("01NX020T2");
     cy.getTestId("card-list-item").last().contains("01NX020");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=descending",
+    );
 
     // rest back to default
     cy.getTestId("select-direction").click();
     cy.getTestId("select-direction-auto").click();
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-card-code").click();
     cy.getTestId("card-list-item").first().contains("01NX020");
     cy.getTestId("card-list-item").last().contains("01NX035");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=card_code",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-name").click();
     cy.getTestId("card-list-item").first().contains("01NX020");
     cy.getTestId("card-list-item").last().contains("01NX020T2");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=name",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-cost").click();
     cy.getTestId("card-list-item").first().contains("01NX035");
     cy.getTestId("card-list-item").last().contains("01NX020T2");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=cost",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-health").click();
     cy.getTestId("card-list-item").first().contains("01NX020T2");
     cy.getTestId("card-list-item").last().contains("01NX020T3");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=health",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-attack").click();
     cy.getTestId("card-list-item").first().contains("01NX020T2");
     cy.getTestId("card-list-item").last().contains("01NX020T3");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=attack",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-card-type").click();
     cy.getTestId("card-list-item").first().contains("01NX020T2");
     cy.getTestId("card-list-item").last().contains("01NX035");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=card_type",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-rarity").click();
     cy.getTestId("card-list-item").first().contains("01NX020T3");
     cy.getTestId("card-list-item").last().contains("01NX020");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=rarity",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-region-refs").click();
-    cy.getTestId("card-list-item").first().contains("01NX020T3");
+    cy.getTestId("card-list-item").first().contains("01NX020");
     cy.getTestId("card-list-item").last().contains("01NX020T2");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=region_refs",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-artist-name").click();
     cy.getTestId("card-list-item").first().contains("01NX020T2");
     cy.getTestId("card-list-item").last().contains("01NX035");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=artist_name",
+    );
 
     cy.getTestId("select-attribute").click();
     cy.getTestId("select-attribute-set").click();
+    cy.getTestId("card-list-item").first().contains("01NX020");
+    cy.getTestId("card-list-item").last().contains("01NX020T2");
+    cy.location("search").should(
+      "eq",
+      "?query=draven&mode=list&direction=auto&attribute=set",
+    );
+  });
+
+  it("should be able to set display modes from URL", () => {
+    cy.visit(
+      "/search?query=draven&mode=list&attribute=attack&direction=descending",
+    );
+    cy.getTestId("card-list-item").should("have.length", 4);
     cy.getTestId("card-list-item").first().contains("01NX020T3");
     cy.getTestId("card-list-item").last().contains("01NX020T2");
+
+    cy.visit(
+      "/search?query=draven&mode=text&attribute=artist_name&direction=ascending",
+    );
+    cy.getTestId("card-text").should("have.length", 4);
+    cy.getTestId("card-text").first().contains("Draven's Whirling Death");
+    cy.getTestId("card-text").last().contains("Draven's Biggest Fan");
+
+    cy.visit("/search?query=draven&mode=asd&attribute=asd&direction=asd");
+    cy.getTestId("card-image").should("have.length", 4);
+    cy.getTestId("card-image")
+      .find("img")
+      .first()
+      .should("have.attr", "src")
+      .should(
+        "include",
+        "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020.png",
+      );
+    cy.getTestId("card-image")
+      .find("img")
+      .last()
+      .should("have.attr", "src")
+      .should(
+        "include",
+        "http://dd.b.pvp.net/5_6_0/set1/en_us/img/cards/01NX020T2.png",
+      );
   });
 });

--- a/src/components/NavSearchBar.tsx
+++ b/src/components/NavSearchBar.tsx
@@ -25,6 +25,7 @@ export default function NavSearchBar() {
           if (e.key === "Enter") {
             if (location.pathname === "/search") {
               searchParams.set("query", search);
+              searchParams.sort();
               setSearchParams(searchParams);
             } else {
               navigate(`/search?query=${search}`);

--- a/src/components/NavSearchBar.tsx
+++ b/src/components/NavSearchBar.tsx
@@ -1,13 +1,12 @@
 import { useState } from "react";
 import { FaMagnifyingGlass } from "react-icons/fa6";
-import { useNavigate, useSearchParams } from "react-router-dom";
+import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 
 export default function NavSearchBar() {
-  const [searchParams] = useSearchParams();
-  const query = searchParams.get("query");
-  const [search, setSearch] = useState(query || "");
-
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [search, setSearch] = useState(searchParams.get("query") || "");
   const navigate = useNavigate();
+  const location = useLocation();
 
   return (
     <div className="relative flex flex-1">
@@ -23,7 +22,14 @@ export default function NavSearchBar() {
         value={search}
         onChange={(e) => setSearch(e.target.value)}
         onKeyDown={(e) => {
-          if (e.key === "Enter") navigate(`/search?query=${search}`);
+          if (e.key === "Enter") {
+            if (location.pathname === "/search") {
+              searchParams.set("query", search);
+              setSearchParams(searchParams);
+            } else {
+              navigate(`/search?query=${search}`);
+            }
+          }
         }}
       />
     </div>

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,50 +1,56 @@
 import CardDisplay from "@/components/display/CardDisplay";
 import SearchFilter from "@/components/SearchFilter/SearchFilter";
 import { Card as CardType, FilterState } from "@/types/interfaces";
-import { Rarity, SortAttribute, SortDirection, SortMode } from "@/types/types";
+import { Rarity } from "@/types/types";
 import { querySearch } from "@/utils/apiCalls";
 import { useEffect, useState } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 import { useNavigate, useSearchParams } from "react-router-dom";
 
 export default function SearchPage() {
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [cards, setCards] = useState<CardType[]>([]);
-  const { showBoundary } = useErrorBoundary();
   const [filterState, setFilterState] = useState<FilterState>({
     sortMode: "image",
     sortAttribute: "name",
     sortDirection: "auto",
   });
   const navigate = useNavigate();
+  const { showBoundary } = useErrorBoundary();
   const { sortMode, sortAttribute, sortDirection } = filterState;
 
   function handleFilterState(action: { type: string; value: string }) {
     switch (action.type) {
       case "sortMode":
-        setFilterState((prevState) => ({
-          ...prevState,
-          sortMode: action.value as SortMode,
-        }));
-        break;
-      case "sortDirection":
-        setFilterState((prevState) => ({
-          ...prevState,
-          sortDirection: action.value as SortDirection,
-        }));
+        searchParams.set("mode", action.value);
+        setSearchParams(searchParams);
         break;
       case "sortAttribute":
-        setFilterState((prevState) => ({
-          ...prevState,
-          sortAttribute: action.value as SortAttribute,
-        }));
+        searchParams.set("attribute", action.value);
+        setSearchParams(searchParams);
         break;
+      case "sortDirection":
+        searchParams.set("direction", action.value);
+        setSearchParams(searchParams);
     }
   }
 
   useEffect(() => {
     const query = searchParams.get("query");
     if (!query) return;
+
+    setFilterState((prevState) => {
+      const sortModeParam = searchParams.get("mode");
+      const sortAttributeParam = searchParams.get("attribute");
+      const sortDirectionParam = searchParams.get("direction");
+
+      return {
+        ...prevState,
+        sortMode: sortModeParam ? sortModeParam : "image",
+        sortAttribute: sortAttributeParam ? sortAttributeParam : "name",
+        sortDirection: sortDirectionParam ? sortDirectionParam : "auto",
+      } as FilterState;
+    });
 
     setCards([]);
     querySearch(query)

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -3,6 +3,11 @@ import SearchFilter from "@/components/SearchFilter/SearchFilter";
 import { Card as CardType, FilterState } from "@/types/interfaces";
 import { Rarity } from "@/types/types";
 import { querySearch } from "@/utils/apiCalls";
+import {
+  isSortAttributeType,
+  isSortDirectionType,
+  isSortModeType,
+} from "@/utils/isType";
 import { useEffect, useState } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -40,15 +45,19 @@ export default function SearchPage() {
     if (!query) return;
 
     setFilterState((prevState) => {
-      const sortModeParam = searchParams.get("mode");
-      const sortAttributeParam = searchParams.get("attribute");
-      const sortDirectionParam = searchParams.get("direction");
+      const sortModeParam = searchParams.get("mode") || "";
+      const sortAttributeParam = searchParams.get("attribute") || "";
+      const sortDirectionParam = searchParams.get("direction") || "";
 
       return {
         ...prevState,
-        sortMode: sortModeParam ? sortModeParam : "image",
-        sortAttribute: sortAttributeParam ? sortAttributeParam : "name",
-        sortDirection: sortDirectionParam ? sortDirectionParam : "auto",
+        sortMode: isSortModeType(sortModeParam) ? sortModeParam : "image",
+        sortAttribute: isSortAttributeType(sortAttributeParam)
+          ? sortAttributeParam
+          : "name",
+        sortDirection: isSortDirectionType(sortDirectionParam)
+          ? sortDirectionParam
+          : "auto",
       } as FilterState;
     });
 

--- a/src/pages/SearchPage.tsx
+++ b/src/pages/SearchPage.tsx
@@ -1,13 +1,13 @@
 import CardDisplay from "@/components/display/CardDisplay";
 import SearchFilter from "@/components/SearchFilter/SearchFilter";
 import { Card as CardType, FilterState } from "@/types/interfaces";
-import { Rarity } from "@/types/types";
 import { querySearch } from "@/utils/apiCalls";
 import {
   isSortAttributeType,
   isSortDirectionType,
   isSortModeType,
 } from "@/utils/isType";
+import { calculateRarity } from "@/utils/rarity";
 import { useEffect, useState } from "react";
 import { useErrorBoundary } from "react-error-boundary";
 import { useNavigate, useSearchParams } from "react-router-dom";
@@ -28,16 +28,15 @@ export default function SearchPage() {
     switch (action.type) {
       case "sortMode":
         searchParams.set("mode", action.value);
-        setSearchParams(searchParams);
         break;
       case "sortAttribute":
         searchParams.set("attribute", action.value);
-        setSearchParams(searchParams);
         break;
       case "sortDirection":
         searchParams.set("direction", action.value);
-        setSearchParams(searchParams);
     }
+    searchParams.sort();
+    setSearchParams(searchParams);
   }
 
   useEffect(() => {
@@ -112,28 +111,11 @@ export default function SearchPage() {
       if (sortDirection === "descending") cardsSorted = cardsSorted.reverse();
       break;
     case "rarity":
-      cardsSorted = cards.sort((card1, card2) => {
-        function calculateRarity(rarity: Rarity) {
-          switch (rarity.toUpperCase()) {
-            default:
-            case "NONE":
-              return 0;
-            case "COMMON":
-              return 1;
-            case "RARE":
-              return 2;
-            case "EPIC":
-              return 3;
-            case "CHAMPION":
-              return 4;
-          }
-        }
-
-        return (
+      cardsSorted = cards.sort(
+        (card1, card2) =>
           calculateRarity(card1.attributes.rarity) -
-          calculateRarity(card2.attributes.rarity)
-        );
-      });
+          calculateRarity(card2.attributes.rarity),
+      );
 
       if (sortDirection === "descending") cardsSorted = cardsSorted.reverse();
       break;

--- a/src/utils/isType.ts
+++ b/src/utils/isType.ts
@@ -1,0 +1,28 @@
+import { SortAttribute, SortDirection, SortMode } from "@/types/types";
+
+export function isSortDirectionType(
+  keyInput: string,
+): keyInput is SortDirection {
+  return ["auto", "ascending", "descending"].includes(keyInput);
+}
+
+export function isSortModeType(keyInput: string): keyInput is SortMode {
+  return ["image", "text", "full", "list"].includes(keyInput);
+}
+
+export function isSortAttributeType(
+  keyInput: string,
+): keyInput is SortAttribute {
+  return [
+    "name",
+    "card_type",
+    "cost",
+    "attack",
+    "health",
+    "set",
+    "rarity",
+    "region_refs",
+    "artist_name",
+    "card_code",
+  ].includes(keyInput);
+}

--- a/src/utils/parse.js
+++ b/src/utils/parse.js
@@ -1,0 +1,18 @@
+export function parseString(string) {
+  return (
+    string
+      // split string using regex
+      .split(/((\w+:".*?"|\w+:\w+)?(\w+:".*?"|\w+:\w+)|\w+)/)
+      // remove all blank words
+      .filter((str) => str && str.trim().length !== 0)
+      // get rid of all non-unique and format correctly
+      .reduce((list, str) => {
+        const [name, key] = str.split(":");
+        return list[name]
+          ? list
+          : { ...list, [name]: key.replace(/^"(.+(?="$))"$/, "$1") };
+      }, {})
+  );
+}
+
+console.log(parseString(`draven:run hey:"asd asda s"`));

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,4 +1,4 @@
-export function parseString(string) {
+export function parseString(string: string) {
   return (
     string
       // split string using regex
@@ -6,7 +6,7 @@ export function parseString(string) {
       // remove all blank words
       .filter((str) => str && str.trim().length !== 0)
       // get rid of all non-unique and format correctly
-      .reduce((list, str) => {
+      .reduce((list: { [key: string]: string }, str) => {
         const [name, key] = str.split(":");
         return list[name]
           ? list

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,3 +1,4 @@
+// add unit testing for this function
 export function parseString(string: string) {
   return (
     string

--- a/src/utils/rarity.ts
+++ b/src/utils/rarity.ts
@@ -1,0 +1,17 @@
+import { Rarity } from "@/types/types";
+
+export function calculateRarity(rarity: Rarity) {
+  switch (rarity.toUpperCase()) {
+    default:
+    case "NONE":
+      return 0;
+    case "COMMON":
+      return 1;
+    case "RARE":
+      return 2;
+    case "EPIC":
+      return 3;
+    case "CHAMPION":
+      return 4;
+  }
+}


### PR DESCRIPTION
# Description

We can now send a URL that will display, sort images in the correct format based on the URL. This URL will change as the settings are changed.

## Context

We currently can set the display mode, sort attribute, and sort direction through the URL. This URL will also update as the settings change on the site.

This almost completes issue #31 ; however, we are still missing the ability to set the display, sort attribute, and direction through the search bar. This is due to runefall/runefall-backend#28

An example of what is missing is below. We currently will get an error saying `display:image` is not a valid keyword, if we type the following.
![image](https://github.com/user-attachments/assets/d10da5b8-3dd6-4848-82b9-75fbcbe818ae)

One solution that I came up with was parsing the string locally, and then removing any invalid keyword, but this seems like more effort than adding a list of keywords that are valid, but will be ignored on the BE.

Due to time constraints, and the fact that half of the feature is working as intended with Cypress testing, I'm submitting it anyways for merging.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] e2e cypress testing in `searchPage.cy.js`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
